### PR TITLE
Remove old dependency

### DIFF
--- a/full_appliance/docker-compose.yaml
+++ b/full_appliance/docker-compose.yaml
@@ -157,8 +157,6 @@ services:
         condition: service_started
       al_ui:
         condition: service_started
-      al_uinext:
-        condition: service_started
 
 
 

--- a/minimal_appliance/docker-compose.yaml
+++ b/minimal_appliance/docker-compose.yaml
@@ -65,8 +65,6 @@ services:
         condition: service_started
       al_ui:
         condition: service_started
-      al_uinext:
-        condition: service_started
 
 
   # Start the core services


### PR DESCRIPTION
Interrupts the docker-compose on both the full and minimal appliance.

al_uinext shouldn't exist anymore since the frontend/UI update