### PR TITLE
Allow privileged images to be tagged with the relevant core tag

### DIFF
--- a/full_appliance/.env
+++ b/full_appliance/.env
@@ -24,3 +24,6 @@ COMPOSE_ROOT=.
 
 # Where do you want docker to find container images? (leave blank unless doing some kind of offline install)
 REGISTRY=
+
+# The prefix given to privileged images followed by a "_"
+COMPOSE_PROJECT_NAME=full_appliance

--- a/full_appliance/docker-compose.yaml
+++ b/full_appliance/docker-compose.yaml
@@ -242,6 +242,7 @@ services:
         registry: ${REGISTRY}
       cache_from:
         - cccs/assemblyline-core:${CORE_VERSION}
+    image: ${COMPOSE_PROJECT_NAME}_al_updater:${CORE_VERSION}
     privileged: true
     env_file: [".env"]
     environment:
@@ -268,6 +269,7 @@ services:
         registry: ${REGISTRY}
       cache_from:
         - cccs/assemblyline-core:${CORE_VERSION}
+    image: ${COMPOSE_PROJECT_NAME}_al_scaler:${CORE_VERSION}
     privileged: true
     env_file: [".env"]
     environment:

--- a/minimal_appliance/.env
+++ b/minimal_appliance/.env
@@ -24,3 +24,6 @@ COMPOSE_ROOT=.
 
 # Where do you want docker to find container images? (leave blank unless doing some kind of offline install)
 REGISTRY=
+
+# The prefix given to privileged images followed by a "_"
+COMPOSE_PROJECT_NAME=minimal_appliance

--- a/minimal_appliance/docker-compose.yaml
+++ b/minimal_appliance/docker-compose.yaml
@@ -136,6 +136,7 @@ services:
         registry: ${REGISTRY}
       cache_from:
         - cccs/assemblyline-core:${CORE_VERSION}
+    image: ${COMPOSE_PROJECT_NAME}_al_updater:${CORE_VERSION}
     privileged: true
     env_file: [".env"]
     environment:
@@ -162,6 +163,7 @@ services:
         registry: ${REGISTRY}
       cache_from:
         - cccs/assemblyline-core:${CORE_VERSION}
+    image: ${COMPOSE_PROJECT_NAME}_al_scaler:${CORE_VERSION}
     privileged: true
     env_file: [".env"]
     environment:


### PR DESCRIPTION
Recommendation from: https://github.com/CybercentreCanada/assemblyline-docker-compose/issues/3

This will allow the privileged images to retain the original name but all the tags will match the core version they were built from, rather than being tagged as 'latest'

Example: Before -> After
full_appliance_al_scaler:latest -> full_appliance_al_scaler:4.0.stable
