### PR TITLE
pass in official ES solution for Elasticsearch

### DIFF
--- a/full_appliance/docker-compose.yaml
+++ b/full_appliance/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
       - discovery.type=single-node
       - logger.level=WARN
       - "ELASTIC_PASSWORD=${ELASTIC_PASSWORD}"
-      - "ES_JAVA_OPTS=-Xms${ELASTIC_MEM}m -Xmx${ELASTIC_MEM}m"
+      - "ES_JAVA_OPTS=-Xms${ELASTIC_MEM}m -Xmx${ELASTIC_MEM}m -Dlog4j2.formatMsgNoLookups=true"
     healthcheck:
         test: ["CMD-SHELL", "curl --silent --fail -u elastic:${ELASTIC_PASSWORD} localhost:9200/_cluster/health || exit 1"]
         interval: 30s

--- a/minimal_appliance/docker-compose.yaml
+++ b/minimal_appliance/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       - discovery.type=single-node
       - logger.level=WARN
       - "ELASTIC_PASSWORD=${ELASTIC_PASSWORD}"
-      - "ES_JAVA_OPTS=-Xms${ELASTIC_MEM}m -Xmx${ELASTIC_MEM}m"
+      - "ES_JAVA_OPTS=-Xms${ELASTIC_MEM}m -Xmx${ELASTIC_MEM}m -Dlog4j2.formatMsgNoLookups=true"
     healthcheck:
         test: ["CMD-SHELL", "curl --silent --fail -u elastic:${ELASTIC_PASSWORD} localhost:9200/_cluster/health || exit 1"]
         interval: 30s


### PR DESCRIPTION
We should consider upgrading our images to use 7.16.1 when it's released to cover items not fixed by this PR (ie. Logstash).