### PR TITLE
Update .env

### DIFF
--- a/full_appliance/.env
+++ b/full_appliance/.env
@@ -4,7 +4,7 @@ SERVICE_VERSION=stable
 
 # Pick the version of assemblyline you which to run
 #  NOTE: You can also lock it down to a specific version if you want
-AL_VERSION=4.1.stable
+AL_VERSION=4.2.stable
 
 # If the appliance is going to have a domain name include it here
 DOMAIN=assemblyline.local

--- a/minimal_appliance/.env
+++ b/minimal_appliance/.env
@@ -4,7 +4,7 @@ SERVICE_VERSION=stable
 
 # Pick the version of assemblyline you which to run
 #  NOTE: You can also lock it down to a specific version if you want
-AL_VERSION=4.1.stable
+AL_VERSION=4.2.stable
 
 # If the appliance is going to have a domain name include it here
 DOMAIN=assemblyline.local


### PR DESCRIPTION
Out of the box, the scaler service will throw errors and disable each running service if the AL version is not 4.2.x. It's likely due to the each service being over this version (e.g, DeobfuScripter running 4.2.0.4). Full write up to come as I investigate further. Changing the AL_VERSION from 4.1.stable to 4.2.stable fixed the issues on Ubuntu 20.04 and docker desktop for Windows 10 and 11.