### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/full_appliance/docker-compose.yaml
+++ b/full_appliance/docker-compose.yaml
@@ -135,6 +135,7 @@ services:
       - FRONTEND_HOST=frontend
       - FQDN=${DOMAIN}
       - MAX_BODY_SIZE=100M
+      - TEMPLATE=full
     volumes:
       - ${COMPOSE_ROOT}/config/nginx.crt:/etc/ssl/nginx.crt:ro
       - ${COMPOSE_ROOT}/config/nginx.key:/etc/ssl/nginx.key:ro


### PR DESCRIPTION
For the full install including kibana, the nginx environment section requires you to add "- TEMPLATE=full". The minimal install reflects a similar line "- TEMPLATE=minimal" by default, but the docker-compose.yaml for some reason didn't include it.