### PR TITLE
Fix Service API Host

### DIFF
--- a/full_appliance/config/apm-server.yml
+++ b/full_appliance/config/apm-server.yml
@@ -20,7 +20,7 @@ output.elasticsearch:
 setup.template.settings:
   index.number_of_shards: 1
   index.number_of_replicas: 0
-  
+
 setup.kibana:
   host: "http://kibana:5601"
   username: ${ELASTIC_USERNAME}

--- a/full_appliance/config/config.yml
+++ b/full_appliance/config/config.yml
@@ -18,8 +18,6 @@ core:
       environment:
         - name: SERVICE_API_KEY
           value: ${SERVICE_API_KEY}
-        - name: SERVICE_API_HOST
-          value: 'http://service-server:5003'
   redis:
     nonpersistent:
       host: redis

--- a/full_appliance/docker-compose.yaml
+++ b/full_appliance/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '2.4'
 
 services:
-  # Dependancies
+  # Dependencies
   minio:
     image: ${REGISTRY}minio/minio
     environment:
@@ -194,7 +194,7 @@ services:
       elasticsearch:
         condition: service_healthy
 
-  # Hearbeat manager
+  # Heartbeat manager
   heartbeat:
     image: ${REGISTRY}cccs/assemblyline-core:${AL_VERSION}
     env_file: [".env"]
@@ -269,7 +269,7 @@ services:
       DOCKER_CONFIGURATION_VOLUME: ${COMPOSE_PROJECT_NAME}_service_config
       AL_CORE_NETWORK: ${COMPOSE_PROJECT_NAME}_core
       UI_SERVER: http://internal_ui:5000
-      SERVICE_API_HOST: http://service_server:5003
+      SERVICE_API_HOST: http://service-server:5003
     volumes:
       - service_config:/mount/service_config:rw
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
@@ -299,7 +299,7 @@ services:
       AL_CORE_NETWORK: ${COMPOSE_PROJECT_NAME}_core
       CONFIGURATION_HOST_PATH: ${COMPOSE_PROJECT_NAME}_service_config
       UI_SERVER: http://internal_ui:5000
-      SERVICE_API_HOST: http://service_server:5003
+      SERVICE_API_HOST: http://service-server:5003
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
       - /var/run/docker.sock:/var/run/docker.sock  # NOTE, this container has access to docker socket (this is like root)

--- a/minimal_appliance/config/config.yml
+++ b/minimal_appliance/config/config.yml
@@ -18,8 +18,6 @@ core:
       environment:
         - name: SERVICE_API_KEY
           value: ${SERVICE_API_KEY}
-        - name: SERVICE_API_HOST
-          value: 'http://service-server:5003'
   redis:
     nonpersistent:
       host: redis

--- a/minimal_appliance/docker-compose.yaml
+++ b/minimal_appliance/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '2.4'
 
 services:
-  # Dependancies
+  # Dependencies
   minio:
     image: ${REGISTRY}minio/minio
     environment:
@@ -101,7 +101,7 @@ services:
       elasticsearch:
         condition: service_healthy
 
-  # Hearbeat manager
+  # Heartbeat manager
   heartbeat:
     image: ${REGISTRY}cccs/assemblyline-core:${AL_VERSION}
     env_file: [".env"]
@@ -176,7 +176,7 @@ services:
       DOCKER_CONFIGURATION_VOLUME: ${COMPOSE_PROJECT_NAME}_service_config
       AL_CORE_NETWORK: ${COMPOSE_PROJECT_NAME}_core
       UI_SERVER: http://internal_ui:5000
-      SERVICE_API_HOST: http://service_server:5003
+      SERVICE_API_HOST: http://service-server:5003
     volumes:
       - service_config:/mount/service_config:rw
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
@@ -206,7 +206,7 @@ services:
       AL_CORE_NETWORK: ${COMPOSE_PROJECT_NAME}_core
       CONFIGURATION_HOST_PATH: ${COMPOSE_PROJECT_NAME}_service_config
       UI_SERVER: http://internal_ui:5000
-      SERVICE_API_HOST: http://service_server:5003
+      SERVICE_API_HOST: http://service-server:5003
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
       - /var/run/docker.sock:/var/run/docker.sock  # NOTE, this container has access to docker socket (this is like root)
@@ -256,6 +256,7 @@ services:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
     networks:
       - core
+      - registration
     depends_on:
       elasticsearch:
         condition: service_healthy

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 ## Assemblyline 4 - Docker compose documentation
 
 There are two types of configuration possible:
-    
+
 - Minimal appliance
 - Full Appliance
 
@@ -17,42 +17,57 @@ This setup includes every single components and all metrics and logging capabili
 
 ## Setup
 
-For full documentation on how to setup an assemblyline appliance see the documentation page. 
+For full documentation on how to setup an assemblyline appliance see the documentation page.
 https://cybercentrecanada.github.io/assemblyline4_docs/
 
 #### Quickstart
 
 ##### 1. Install docker and docker-compose on a linux system
+```NOTE:``` If using the Docker Compose plugin, replace `docker-compose` commands with `docker compose`.
+
 ##### 2. Clone this repository
+```bash
+git clone https://github.com/CybercentreCanada/assemblyline-docker-compose.git
+```
 
-    git clone https://github.com/CybercentreCanada/assemblyline-docker-compose.git
-
-##### 3 Choose deployment type
-
-Choose one of the minimal or full deployments. The rest of the commands 
+##### 3. Choose deployment type
+Choose one of the minimal or full deployments. The rest of the commands
 and paths given will be relative to the directory specific to the deployment
-type you are doing. 
-    
-    cd assemblyline-docker-compose/minimal_appliance
+type you are doing.
+```bash
+mkdir ~/deployments
+cp -R ~/git/assemblyline-docker-compose/minimal_appliance ~/deployments/assemblyline
+cd ~/deployments/assemblyline
+```
 
 or
 
-    cd assemblyline-docker-compose/full_appliance
+```bash
+mkdir ~/deployments
+cp -R ~/git/assemblyline-docker-compose/full_appliance ~/deployments/assemblyline
+cd ~/deployments/assemblyline
+```
 
-##### 4. Copy in an existing or generate a self signed certificate into the `./config` directory in the cloned repository
-    
-    openssl req -nodes -x509 -newkey rsa:4096 -keyout ./config/nginx.key -out ./config/nginx.crt -days 365 -subj "/C=CA/ST=Ontario/L=Ottawa/O=CCCS/CN=assemblyline.local"
-    
-##### 5. Set passwords and paths in `./.env` and `./config/bootstrap.py`
+##### 4. Set domain, passwords, and paths in `./.env` and `./config/bootstrap.py`
+
+##### 5. Copy in an existing or generate a self-signed certificate into the `./config` directory in the cloned repository
+```bash
+source .env
+openssl req -nodes -x509 -newkey rsa:4096 -keyout ./config/nginx.key -out ./config/nginx.crt -days 365 -subj "/C=CA/ST=Ontario/L=Ottawa/O=CCCS/CN=$DOMAIN"
+```
+
 ##### 6. Launch the system
-    
-Pull the containers and launch the core system.
-    
-    sudo docker-compose pull
-    sudo docker-compose up -d
-
-Pull the containers and perform first time only setup and install.
-
-    sudo docker-compose -f bootstrap-compose.yaml pull 
-    sudo docker-compose -f bootstrap-compose.yaml up -d 
- 
+Pull the containers.
+```bash
+sudo docker-compose pull
+sudo docker-compose build
+sudo docker-compose -f bootstrap-compose.yaml pull
+```
+Launch the core system.
+```bash
+sudo docker-compose up -d
+```
+Perform first time only setup and service initialization.
+```bash
+sudo docker-compose -f bootstrap-compose.yaml up
+ ```


### PR DESCRIPTION
It appears that changes in the core or base configuration broke the Compose deployments.  The significant changes are in `docker-compose.yml` and `config/config.yml`, regarding how `SERVICE_API_HOST` is set in the service containers.
