### PR TITLE
Stage Classification Enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 *.crt
 *.key
+.env

--- a/full_appliance/bootstrap-compose.yaml
+++ b/full_appliance/bootstrap-compose.yaml
@@ -7,6 +7,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
       - ${COMPOSE_ROOT}/config/bootstrap.py:/tmp/bootstrap.py:ro
     command: python3 /tmp/bootstrap.py
     networks: [core]
@@ -21,6 +22,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # APKaye service
   service_apkaye:
@@ -32,6 +34,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # # Antivirus service
   # service_antivirus:
@@ -43,6 +46,7 @@ services:
   #   networks: [core]
   #   volumes:
   #     - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+  #     #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Ancestry service
   service_ancestry:
@@ -54,6 +58,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # AVClass service
   service_avclass:
@@ -65,6 +70,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # BatchDeobfuscator service
   service_batchdeobfuscator:
@@ -76,6 +82,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # CAPA service
   service_capa:
@@ -87,6 +94,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # # CAPE service
   # service_cape:
@@ -98,6 +106,7 @@ services:
   #   networks: [core]
   #   volumes:
   #     - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+  #     #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Characterize service
   service_characterize:
@@ -109,6 +118,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # # ConfigExtractor service
   # service_configextractor:
@@ -120,6 +130,7 @@ services:
   #   networks: [core]
   #   volumes:
   #     - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+  #     #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # # Cuckoo service
   # service_cuckoo:
@@ -131,6 +142,7 @@ services:
   #   networks: [core]
   #   volumes:
   #     - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+  #     #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Deobfuscripter service
   service_deobfuscripter:
@@ -142,6 +154,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # DocumentPreview service
   service_document_preview:
@@ -153,6 +166,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # ELF service
   service_elf:
@@ -164,6 +178,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # ELFPARSER service
   service_elfparser:
@@ -175,6 +190,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # EmlParser service
   service_emlparser:
@@ -186,6 +202,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Espresso service
   service_espresso:
@@ -197,6 +214,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Extract service
   service_extract:
@@ -208,6 +226,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Floss service
   service_floss:
@@ -219,6 +238,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Frankenstrings service
   service_frankenstrings:
@@ -230,6 +250,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # # Intezer service
   # service_intezer:
@@ -241,6 +262,7 @@ services:
   #   networks: [core]
   #   volumes:
   #     - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # iParse service
   service_iparse:
@@ -252,6 +274,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # JsJaws service
   service_jsjaws:
@@ -263,6 +286,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # # MetaDefender service
   # service_metadefender:
@@ -274,6 +298,7 @@ services:
   #   networks: [core]
   #   volumes:
   #     - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # MetaPeek service
   service_metapeek:
@@ -285,6 +310,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # OleTools service
   service_oletools:
@@ -296,6 +322,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Overpower service
   service_overpower:
@@ -307,6 +334,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # PDFiD service
   service_pdfid:
@@ -318,6 +346,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # PE service
   service_pe:
@@ -329,6 +358,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # PeePDF service
   service_peepdf:
@@ -340,6 +370,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Pixaxe service
   service_pixaxe:
@@ -351,6 +382,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Safelist service
   service_safelist:
@@ -362,6 +394,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Sigma service
   service_sigma:
@@ -373,6 +406,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Suricata service
   service_suricata:
@@ -384,6 +418,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Swiffer service
   service_swiffer:
@@ -395,6 +430,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # TagCheck service
   service_tagcheck:
@@ -406,6 +442,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # TorrentSlicer service
   service_torrentslicer:
@@ -417,6 +454,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Unpacker service
   service_unpacker:
@@ -428,6 +466,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # # Unpacme service
   # service_unpacme:
@@ -439,6 +478,7 @@ services:
   #   networks: [core]
   #   volumes:
   #     - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # URLDownloader service
   service_urldownloader:
@@ -450,6 +490,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # ViperMonkey service
   service_vipermonkey:
@@ -461,6 +502,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # # VirusTotal service
   # service_virustotal:
@@ -472,6 +514,7 @@ services:
   #   networks: [core]
   #   volumes:
   #     - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Yara service
   service_yara:
@@ -483,6 +526,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # XLMMacroDeobfuscator service
   service_xlmmacrodeobfuscator:
@@ -494,6 +538,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
 networks:
   core:

--- a/full_appliance/config/classification.yml
+++ b/full_appliance/config/classification.yml
@@ -1,0 +1,158 @@
+# Turn on/off classification enforcement. When this flag is off, this
+#  completely disables the classification engine, any documents added while
+#  the classification engine is off getting the default unrestricted value
+enforce: false
+
+# When this flag is on, the classification engine will automatically create
+#  groups based on the domain part of a user's email address
+#  EX:
+#     For user with email: test@local.host
+#     The group "local.host" will be valid in the system
+dynamic_groups: false
+
+# List of Classification Levels:
+#   This is a graded list; a smaller number is less restricted than a higher number
+#   A user must be allowed a classification level >= to be able to view the data
+levels:
+  # List of alternate names for the current marking. If a user submits a file with
+  #  those markings, the classification will automatically rename it to the value
+  #  specified in the name
+  - aliases:
+      - UNRESTRICTED
+      - UNCLASSIFIED
+      - U
+
+    # Stylesheet applied in the UI for the current classification level
+    css:
+      # Name of the color scheme used for display
+      # Possible values: default, primary, secondary, success, info, warning, error
+      color: default
+
+      # Deprecated parameters (Use color instead)
+      #  These were used in the old UI but are still valid in the new UI because if
+      #  the new UI cannot find the color param, it will use the label param and
+      #  strips "label-" part.
+      banner: alert-default
+      label: label-default
+      text: text-muted
+
+    # Description of the classification level
+    description:
+      Subject to standard copyright rules, TLP:WHITE information may be distributed
+      without restriction.
+
+    # Integer value of the Classification level (higher is more classified)
+    lvl: 100
+
+    # Long name of the classification level
+    name: TLP:WHITE
+
+    # Short name of the classification level
+    short_name: TLP:W
+  - aliases: []
+    css:
+      color: success
+    description:
+      Recipients may share TLP:GREEN information with peers and partner organizations
+      within their sector or community, but not via publicly accessible channels.
+      Information in this category can be circulated widely within a particular
+      community. TLP:GREEN information may not be released outside of the community.
+    lvl: 110
+    name: TLP:GREEN
+    short_name: TLP:G
+  - aliases:
+      - RESTRICTED
+    css:
+      color: warning
+    description:
+      Recipients may only share TLP:AMBER information with members of their
+      own organization and with clients or customers who need to know the information
+      to protect themselves or prevent further harm.
+    lvl: 120
+    name: TLP:AMBER
+    short_name: TLP:A
+
+# List of required tokens:
+#   A user requesting access to an item must have all the
+#   required tokens the item has, to gain access to it
+required:
+  # List of alternate names for the token
+  - aliases: []
+
+    # Description of the token
+    description: Produced using a commercial tool with limited distribution
+
+    # Long name for the token
+    name: COMMERCIAL
+
+    # Short name for the token
+    short_name: CMR
+
+    # (optional) The minimum classification level an item must have
+    #  for this token to be valid. So, because this token has a value
+    #  of 120, once it's selected, the classification level automatically
+    #  jumps to TPL:A which was set to 120 in the previous section.
+    require_lvl: 120
+
+# List of groups:
+#   A user requesting access to an item must be part of a least
+#   of one the group the item is part of to gain access
+groups:
+  # List of aliases for the group
+  - aliases:
+      - ANY
+    # (optional) This is a special flag that when set to true if any other groups
+    #  are selected in a classification, this group will automatically be selected
+    #  as well.
+    auto_select: true
+
+    # Description of the group
+    description: Employees of CSE
+
+    # Long name for the group
+    name: CSE
+
+    # Short name for the group
+    short_name: CSE
+
+    # (optional) Assuming that this group is the only group selected, this is the
+    #   display name that will be used in the classification
+    #   NOTE: values must be in the aliases of this group and only this group
+    solitary_display_name: ANY
+
+# List of sub-groups:
+#   A user requesting access to an item must be part of a least
+#   of one the sub-group the item is part of to gain access
+subgroups:
+  # List of aliases for the subgroups
+  - aliases: []
+
+    # Description of the sub-group
+    description: Member of Incident Response team
+
+    # Long name of the sub-group
+    name: IR TEAM
+
+    # Short name of the sub-group
+    short_name: IR
+  - aliases: []
+    description: Member of the Canadian Centre for Cyber Security
+
+    # (optional) This is a special flag that auto select the corresponding
+    #   group when this sub-group is selected
+    require_group: CSE
+
+    name: CCCS
+    short_name: CCCS
+
+    # (optional) This is a special flag that makes sure that none other than
+    #   the corresponding group is selected when this sub-group is selected
+    limited_to_group: CSE
+
+# Default restricted classification
+restricted: TLP:A//CMR
+
+# Default unrestricted classification:
+#   When no classification is provided or the classification engine is
+#   disabled, this is the classification value each item will get
+unrestricted: TLP:W

--- a/full_appliance/docker-compose.yaml
+++ b/full_appliance/docker-compose.yaml
@@ -183,6 +183,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.alerter.run_alerter
@@ -198,6 +199,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.archiver.run_archiver
@@ -213,6 +215,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.expiry.run_expiry
@@ -228,6 +231,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.metrics.run_metrics_aggregator
@@ -241,6 +245,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.metrics.run_heartbeat_manager
@@ -256,6 +261,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.plumber.run_plumber
@@ -271,6 +277,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.metrics.run_statistics_aggregator
@@ -284,6 +291,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.workflow.run_workflow
@@ -313,6 +321,7 @@ services:
     volumes:
       - service_config:/mount/service_config:rw
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
       - /var/run/docker.sock:/var/run/docker.sock  # NOTE, this container has access to docker socket (this is like root)
     networks: [core]
     restart: on-failure
@@ -341,6 +350,7 @@ services:
       SERVICE_API_HOST: http://service-server:5003
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
       - /var/run/docker.sock:/var/run/docker.sock  # NOTE, this container has access to docker socket (this is like root)
     command: python3 -m assemblyline_core.updater.run_updater
     networks: [core, external]
@@ -357,6 +367,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.dispatching
@@ -372,6 +383,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.ingester
@@ -386,6 +398,7 @@ services:
     image: ${REGISTRY}cccs/assemblyline-service-server:${AL_VERSION}
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks:
       - core
       - registration
@@ -405,6 +418,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core, external]
     restart: on-failure
     depends_on:
@@ -417,6 +431,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     depends_on:

--- a/full_appliance/template.env
+++ b/full_appliance/template.env
@@ -1,10 +1,10 @@
 # Choose your the service release channel: stable or latest
 #  NOTE: This is only used once during the bootstrap process
-SERVICE_VERSION=4.4.stable
+SERVICE_VERSION=4.5.stable
 
 # Pick the version of assemblyline you which to run
 #  NOTE: You can also lock it down to a specific version if you want
-AL_VERSION=4.4.stable
+AL_VERSION=4.5.stable
 
 # If the appliance is going to have a domain name include it here
 DOMAIN=assemblyline.local
@@ -18,6 +18,10 @@ SERVICE_API_KEY=password_789
 #  NOTE: this is only used in the bootstrap process
 AL_ADMIN_USER=admin
 AL_ADMIN_PASSWORD=admin
+
+# Kibana username/password
+KIBANA_USERNAME=kibana_system
+KIBANA_PASSWORD=kb_password_456
 
 # Amount of memory allocated to elasticsearch
 ELASTIC_MEM=2048

--- a/minimal_appliance/bootstrap-compose.yaml
+++ b/minimal_appliance/bootstrap-compose.yaml
@@ -7,6 +7,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
       - ${COMPOSE_ROOT}/config/bootstrap.py:/tmp/bootstrap.py:ro
     command: python3 /tmp/bootstrap.py
     networks: [core]
@@ -21,6 +22,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # APKaye service
   service_apkaye:
@@ -32,6 +34,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # # Antivirus service
   # service_antivirus:
@@ -43,6 +46,7 @@ services:
   #   networks: [core]
   #   volumes:
   #     - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+  #     #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Ancestry service
   service_ancestry:
@@ -54,6 +58,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # AVClass service
   service_avclass:
@@ -65,6 +70,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # BatchDeobfuscator service
   service_batchdeobfuscator:
@@ -76,6 +82,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # CAPA service
   service_capa:
@@ -87,6 +94,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # # CAPE service
   # service_cape:
@@ -98,6 +106,7 @@ services:
   #   networks: [core]
   #   volumes:
   #     - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+  #     #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Characterize service
   service_characterize:
@@ -109,6 +118,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # # ConfigExtractor service
   # service_configextractor:
@@ -120,6 +130,7 @@ services:
   #   networks: [core]
   #   volumes:
   #     - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+  #     #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # # Cuckoo service
   # service_cuckoo:
@@ -131,6 +142,7 @@ services:
   #   networks: [core]
   #   volumes:
   #     - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+  #     #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Deobfuscripter service
   service_deobfuscripter:
@@ -142,6 +154,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # DocumentPreview service
   service_document_preview:
@@ -153,6 +166,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # ELF service
   service_elf:
@@ -164,6 +178,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # ELFPARSER service
   service_elfparser:
@@ -175,6 +190,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # EmlParser service
   service_emlparser:
@@ -186,6 +202,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Espresso service
   service_espresso:
@@ -197,6 +214,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Extract service
   service_extract:
@@ -208,6 +226,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Floss service
   service_floss:
@@ -219,6 +238,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Frankenstrings service
   service_frankenstrings:
@@ -230,6 +250,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # # Intezer service
   # service_intezer:
@@ -241,6 +262,7 @@ services:
   #   networks: [core]
   #   volumes:
   #     - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+  #     #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # iParse service
   service_iparse:
@@ -252,6 +274,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # JsJaws service
   service_jsjaws:
@@ -263,6 +286,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # # MetaDefender service
   # service_metadefender:
@@ -274,6 +298,7 @@ services:
   #   networks: [core]
   #   volumes:
   #     - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+  #     #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # MetaPeek service
   service_metapeek:
@@ -285,6 +310,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # OleTools service
   service_oletools:
@@ -296,6 +322,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Overpower service
   service_overpower:
@@ -307,6 +334,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # PDFiD service
   service_pdfid:
@@ -318,6 +346,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # PE service
   service_pe:
@@ -329,6 +358,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # PeePDF service
   service_peepdf:
@@ -340,6 +370,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Pixaxe service
   service_pixaxe:
@@ -351,6 +382,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Safelist service
   service_safelist:
@@ -362,6 +394,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Sigma service
   service_sigma:
@@ -373,6 +406,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Suricata service
   service_suricata:
@@ -384,6 +418,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Swiffer service
   service_swiffer:
@@ -395,6 +430,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # TagCheck service
   service_tagcheck:
@@ -406,6 +442,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # TorrentSlicer service
   service_torrentslicer:
@@ -417,6 +454,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Unpacker service
   service_unpacker:
@@ -428,6 +466,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # # Unpacme service
   # service_unpacme:
@@ -439,6 +478,7 @@ services:
   #   networks: [core]
   #   volumes:
   #     - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+  #     #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # URLDownloader service
   service_urldownloader:
@@ -450,6 +490,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # ViperMonkey service
   service_vipermonkey:
@@ -461,6 +502,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # # VirusTotal service
   # service_virustotal:
@@ -472,6 +514,7 @@ services:
   #   networks: [core]
   #   volumes:
   #     - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+  #     #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # Yara service
   service_yara:
@@ -483,6 +526,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
   # XLMMacroDeobfuscator service
   service_xlmmacrodeobfuscator:
@@ -494,6 +538,7 @@ services:
     networks: [core]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
 
 networks:
   core:

--- a/minimal_appliance/config/classification.yml
+++ b/minimal_appliance/config/classification.yml
@@ -1,0 +1,158 @@
+# Turn on/off classification enforcement. When this flag is off, this
+#  completely disables the classification engine, any documents added while
+#  the classification engine is off getting the default unrestricted value
+enforce: false
+
+# When this flag is on, the classification engine will automatically create
+#  groups based on the domain part of a user's email address
+#  EX:
+#     For user with email: test@local.host
+#     The group "local.host" will be valid in the system
+dynamic_groups: false
+
+# List of Classification Levels:
+#   This is a graded list; a smaller number is less restricted than a higher number
+#   A user must be allowed a classification level >= to be able to view the data
+levels:
+  # List of alternate names for the current marking. If a user submits a file with
+  #  those markings, the classification will automatically rename it to the value
+  #  specified in the name
+  - aliases:
+      - UNRESTRICTED
+      - UNCLASSIFIED
+      - U
+
+    # Stylesheet applied in the UI for the current classification level
+    css:
+      # Name of the color scheme used for display
+      # Possible values: default, primary, secondary, success, info, warning, error
+      color: default
+
+      # Deprecated parameters (Use color instead)
+      #  These were used in the old UI but are still valid in the new UI because if
+      #  the new UI cannot find the color param, it will use the label param and
+      #  strips "label-" part.
+      banner: alert-default
+      label: label-default
+      text: text-muted
+
+    # Description of the classification level
+    description:
+      Subject to standard copyright rules, TLP:WHITE information may be distributed
+      without restriction.
+
+    # Integer value of the Classification level (higher is more classified)
+    lvl: 100
+
+    # Long name of the classification level
+    name: TLP:WHITE
+
+    # Short name of the classification level
+    short_name: TLP:W
+  - aliases: []
+    css:
+      color: success
+    description:
+      Recipients may share TLP:GREEN information with peers and partner organizations
+      within their sector or community, but not via publicly accessible channels.
+      Information in this category can be circulated widely within a particular
+      community. TLP:GREEN information may not be released outside of the community.
+    lvl: 110
+    name: TLP:GREEN
+    short_name: TLP:G
+  - aliases:
+      - RESTRICTED
+    css:
+      color: warning
+    description:
+      Recipients may only share TLP:AMBER information with members of their
+      own organization and with clients or customers who need to know the information
+      to protect themselves or prevent further harm.
+    lvl: 120
+    name: TLP:AMBER
+    short_name: TLP:A
+
+# List of required tokens:
+#   A user requesting access to an item must have all the
+#   required tokens the item has, to gain access to it
+required:
+  # List of alternate names for the token
+  - aliases: []
+
+    # Description of the token
+    description: Produced using a commercial tool with limited distribution
+
+    # Long name for the token
+    name: COMMERCIAL
+
+    # Short name for the token
+    short_name: CMR
+
+    # (optional) The minimum classification level an item must have
+    #  for this token to be valid. So, because this token has a value
+    #  of 120, once it's selected, the classification level automatically
+    #  jumps to TPL:A which was set to 120 in the previous section.
+    require_lvl: 120
+
+# List of groups:
+#   A user requesting access to an item must be part of a least
+#   of one the group the item is part of to gain access
+groups:
+  # List of aliases for the group
+  - aliases:
+      - ANY
+    # (optional) This is a special flag that when set to true if any other groups
+    #  are selected in a classification, this group will automatically be selected
+    #  as well.
+    auto_select: true
+
+    # Description of the group
+    description: Employees of CSE
+
+    # Long name for the group
+    name: CSE
+
+    # Short name for the group
+    short_name: CSE
+
+    # (optional) Assuming that this group is the only group selected, this is the
+    #   display name that will be used in the classification
+    #   NOTE: values must be in the aliases of this group and only this group
+    solitary_display_name: ANY
+
+# List of sub-groups:
+#   A user requesting access to an item must be part of a least
+#   of one the sub-group the item is part of to gain access
+subgroups:
+  # List of aliases for the subgroups
+  - aliases: []
+
+    # Description of the sub-group
+    description: Member of Incident Response team
+
+    # Long name of the sub-group
+    name: IR TEAM
+
+    # Short name of the sub-group
+    short_name: IR
+  - aliases: []
+    description: Member of the Canadian Centre for Cyber Security
+
+    # (optional) This is a special flag that auto select the corresponding
+    #   group when this sub-group is selected
+    require_group: CSE
+
+    name: CCCS
+    short_name: CCCS
+
+    # (optional) This is a special flag that makes sure that none other than
+    #   the corresponding group is selected when this sub-group is selected
+    limited_to_group: CSE
+
+# Default restricted classification
+restricted: TLP:A//CMR
+
+# Default unrestricted classification:
+#   When no classification is provided or the classification engine is
+#   disabled, this is the classification value each item will get
+unrestricted: TLP:W

--- a/minimal_appliance/docker-compose.yaml
+++ b/minimal_appliance/docker-compose.yaml
@@ -77,6 +77,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.alerter.run_alerter
@@ -92,6 +93,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.archiver.run_archiver
@@ -107,6 +109,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.expiry.run_expiry
@@ -122,6 +125,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.metrics.run_heartbeat_manager
@@ -137,6 +141,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.plumber.run_plumber
@@ -152,6 +157,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.metrics.run_statistics_aggregator
@@ -165,6 +171,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.workflow.run_workflow
@@ -194,6 +201,7 @@ services:
     volumes:
       - service_config:/mount/service_config:rw
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
       - /var/run/docker.sock:/var/run/docker.sock  # NOTE, this container has access to docker socket (this is like root)
     networks: [core]
     restart: on-failure
@@ -222,6 +230,7 @@ services:
       SERVICE_API_HOST: http://service-server:5003
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
       - /var/run/docker.sock:/var/run/docker.sock  # NOTE, this container has access to docker socket (this is like root)
     command: python3 -m assemblyline_core.updater.run_updater
     networks: [core, external]
@@ -238,6 +247,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.dispatching
@@ -253,6 +263,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     command: python -m assemblyline_core.ingester
@@ -267,6 +278,7 @@ services:
     image: ${REGISTRY}cccs/assemblyline-service-server:${AL_VERSION}
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks:
       - core
       - registration
@@ -287,6 +299,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core, external]
     restart: on-failure
     depends_on:
@@ -299,6 +312,7 @@ services:
     env_file: [".env"]
     volumes:
       - ${COMPOSE_ROOT}/config/config.yml:/etc/assemblyline/config.yml:ro
+      #- ${COMPOSE_ROOT}/config/classification.yml:/etc/assemblyline/classification.yml:ro
     networks: [core]
     restart: on-failure
     depends_on:

--- a/minimal_appliance/template.env
+++ b/minimal_appliance/template.env
@@ -1,10 +1,10 @@
 # Choose your the service release channel: stable or latest
 #  NOTE: This is only used once during the bootstrap process
-SERVICE_VERSION=4.4.stable
+SERVICE_VERSION=4.5.stable
 
 # Pick the version of assemblyline you which to run
 #  NOTE: You can also lock it down to a specific version if you want
-AL_VERSION=4.4.stable
+AL_VERSION=4.5.stable
 
 # If the appliance is going to have a domain name include it here
 DOMAIN=assemblyline.local
@@ -18,10 +18,6 @@ SERVICE_API_KEY=password_789
 #  NOTE: this is only used in the bootstrap process
 AL_ADMIN_USER=admin
 AL_ADMIN_PASSWORD=admin
-
-# Kibana username/password
-KIBANA_USERNAME=kibana_system
-KIBANA_PASSWORD=kb_password_456
 
 # Amount of memory allocated to elasticsearch
 ELASTIC_MEM=2048

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,7 @@ type you are doing.
 mkdir ~/deployments
 cp -R ~/git/assemblyline-docker-compose/minimal_appliance ~/deployments/assemblyline
 cd ~/deployments/assemblyline
+cp -n ./template.env ./.env
 ```
 
 or
@@ -46,9 +47,12 @@ or
 mkdir ~/deployments
 cp -R ~/git/assemblyline-docker-compose/full_appliance ~/deployments/assemblyline
 cd ~/deployments/assemblyline
+cp -n ./template.env ./.env
 ```
 
-##### 4. Set domain, passwords, and paths in `./.env` and `./config/bootstrap.py`
+##### 4. Set domain, passwords, and paths in `./.env`
+
+Optionally set initial admin user display name and other details in `./config/bootstrap.py`.
 
 ##### 5. Copy in an existing or generate a self-signed certificate into the `./config` directory in the cloned repository
 ```bash


### PR DESCRIPTION
Stage CCCS `classification.yml` for easier implementation. To enable the extra configuration, the lines in the compose files only need to be uncommented and `enforce: true` set in  `classification.yml`.

Moved `.env` to `template.env` and added `.env` to `.gitignore` to decrease possibility of committing passwords.

Bumped version to recent 4.5 release.

@cccs-rs 