### PR TITLE
Move '/' for elasticsearch image reference to work with custom registry

### DIFF
--- a/common/elasticsearch.yaml
+++ b/common/elasticsearch.yaml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: ${REGISTRY:-docker.elastic.co}/elasticsearch/elasticsearch:8.10.2
+    image: ${REGISTRY:-docker.elastic.co/}elasticsearch/elasticsearch:8.10.2
     environment:
       - ingest.geoip.downloader.enabled=false
       - xpack.security.enabled=true


### PR DESCRIPTION
Referring to [this message](https://discord.com/channels/908084610158714900/908717528082173983/1397243521601376509) on the discord. 

When deploying assemblyline-docker-compose using a custom registry set in .env, user needs to include a trailing slash in the registry's name. This is appropriate for how the [docker-compose.yaml](https://github.com/CybercentreCanada/assemblyline-docker-compose/blob/028508afa85faedc28ecdadba885089e3050f510/docker-compose.yaml#L40) file is structured. 


However, there is an invalid reference format error from docker-compose when it goes to pull the elasticsearch image. The image reference in [elasticsearch.yaml](https://github.com/CybercentreCanada/assemblyline-docker-compose/blob/028508afa85faedc28ecdadba885089e3050f510/common/elasticsearch.yaml#L3) includes that trailing slash from the registry variable. The result is that it tries to pull an image that has a double slash in the reference.

Moved the extra slash so it only applies when pulling without a custom registry.